### PR TITLE
Add session checks and authorization for update endpoints

### DIFF
--- a/update_cost.php
+++ b/update_cost.php
@@ -1,6 +1,22 @@
 <?php
 // update_cost.php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 header('Content-Type: application/json');
+
+// Verify authentication and authorization (Admin or higher)
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+$allowedRoles = ['Admin', 'Manager', 'Super Admin'];
+if (!in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Forbidden']);
+    exit;
+}
 
 require_once __DIR__ . '/assets/database.php';
 

--- a/update_notes.php
+++ b/update_notes.php
@@ -1,6 +1,22 @@
 <?php
 // update_notes.php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 header('Content-Type: application/json');
+
+// Ensure user is logged in and has sufficient privileges (Admin or higher)
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+$allowedRoles = ['Admin', 'Manager', 'Super Admin'];
+if (!in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Forbidden']);
+    exit;
+}
 
 require_once __DIR__ . '/assets/database.php';
 

--- a/update_status.php
+++ b/update_status.php
@@ -5,6 +5,19 @@ if (session_status() === PHP_SESSION_NONE) {
 }
 header('Content-Type: application/json');
 
+// Verify authentication and authorization (Admin or higher)
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    exit;
+}
+$allowedRoles = ['Admin', 'Manager', 'Super Admin'];
+if (!in_array($_SESSION['role'] ?? '', $allowedRoles, true)) {
+    http_response_code(403);
+    echo json_encode(['success' => false, 'error' => 'Forbidden']);
+    exit;
+}
+
 require_once __DIR__ . '/assets/database.php';
 require_once __DIR__ . '/helpers/encryption.php';
 require_once __DIR__ . '/libs/phpmailer/src/Exception.php';


### PR DESCRIPTION
## Summary
- Ensure sessions start in update endpoints.
- Require authenticated Admin, Manager, or Super Admin roles for updating ticket notes, cost, or status.

## Testing
- `php -l update_notes.php`
- `php -l update_cost.php`
- `php -l update_status.php`


------
https://chatgpt.com/codex/tasks/task_b_689267d37c4c8326a830d853ddb6dbea