### PR TITLE
Use environment variables for sensitive config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+.env

--- a/assets/database.php
+++ b/assets/database.php
@@ -1,10 +1,17 @@
 <?php
 // database.php
 
-$dbHost = 'localhost';
-$dbName = 'riohondoprint_printing';
-$dbUser = 'riohondoprint_printing';
-$dbPass = 'USarmy2016!?';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$dotenvPath = dirname(__DIR__, 2);
+if (file_exists($dotenvPath . '/.env')) {
+    Dotenv\Dotenv::createImmutable($dotenvPath)->safeLoad();
+}
+
+$dbHost = getenv('DB_HOST') ?: $_ENV['DB_HOST'] ?? $_SERVER['DB_HOST'] ?? '';
+$dbName = getenv('DB_NAME') ?: $_ENV['DB_NAME'] ?? $_SERVER['DB_NAME'] ?? '';
+$dbUser = getenv('DB_USER') ?: $_ENV['DB_USER'] ?? $_SERVER['DB_USER'] ?? '';
+$dbPass = getenv('DB_PASS') ?: $_ENV['DB_PASS'] ?? $_SERVER['DB_PASS'] ?? '';
 
 /**
  * Convert a MySQL timestamp string (assumed UTC) to Los Angeles time.
@@ -35,3 +42,4 @@ try {
 } catch (PDOException $e) {
     die('Database Connection Failed: ' . $e->getMessage());
 }
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "vlucas/phpdotenv": "^5.5"
+    }
+}

--- a/config/smtp_key.php
+++ b/config/smtp_key.php
@@ -1,3 +1,12 @@
 <?php
 
-define('SMTP_ENC_KEY', 'd087458cb5e5d0b30f1bf61b78dc73e36847000247749b3693485e911b9a0459');
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$dotenvPath = dirname(__DIR__, 2);
+if (file_exists($dotenvPath . '/.env')) {
+    Dotenv\Dotenv::createImmutable($dotenvPath)->safeLoad();
+}
+
+define('SMTP_ENC_KEY', getenv('SMTP_ENC_KEY') ?: $_ENV['SMTP_ENC_KEY'] ?? $_SERVER['SMTP_ENC_KEY'] ?? '');
+
+

--- a/login.php
+++ b/login.php
@@ -5,8 +5,10 @@ if (session_status() === PHP_SESSION_NONE) {
 require_once 'assets/database.php';
 
 // ─── Cloudflare Turnstile keys ────────────────────────────
-const TURNSTILE_SITEKEY   = '0x4AAAAAABTq_ONo-n-WmTXx';
-const TURNSTILE_SECRETKEY = '0x4AAAAAABTq_Nu_8P75bfRW3vmrBBDDoyQ';
+$turnstileSiteKey = getenv('TURNSTILE_SITEKEY')
+    ?: $_ENV['TURNSTILE_SITEKEY'] ?? $_SERVER['TURNSTILE_SITEKEY'] ?? '';
+$turnstileSecretKey = getenv('TURNSTILE_SECRET')
+    ?: $_ENV['TURNSTILE_SECRET'] ?? $_SERVER['TURNSTILE_SECRET'] ?? '';
 // ──────────────────────────────────────────────────────────
 
 
@@ -158,7 +160,7 @@ require_once 'header.php';
           <input class="form-check-input" type="checkbox" name="remember" id="remember">
           <label class="form-check-label" for="remember">Remember Me</label>
         </div>
-        <div class="cf-turnstile mb-3" data-sitekey="<?= TURNSTILE_SITEKEY ?>"></div>
+        <div class="cf-turnstile mb-3" data-sitekey="<?= htmlspecialchars($turnstileSiteKey) ?>"></div>
         <div class="d-grid gap-2">
           <button type="submit" class="btn btn-primary">Login</button>
           <a href="forgot_password.php" class="btn btn-link">Forgot Password?</a>
@@ -169,3 +171,4 @@ require_once 'header.php';
 </div>
 
 <?php require_once 'footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- Load environment variables with vlucas/phpdotenv and use them for database connection, SMTP key and Turnstile keys
- Replace hardcoded credentials with getenv/$_ENV/$_SERVER lookups
- Ignore `.env` and vendor directories in version control

## Testing
- `php -l assets/database.php config/smtp_key.php login.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json)*

------
https://chatgpt.com/codex/tasks/task_b_689284f546bc8326921f22b088fb5b78