### PR TITLE
Reuse shared PDO connection

### DIFF
--- a/assets/database.php
+++ b/assets/database.php
@@ -43,3 +43,5 @@ try {
     die('Database Connection Failed: ' . $e->getMessage());
 }
 
+return $pdo;
+

--- a/header.php
+++ b/header.php
@@ -4,14 +4,8 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
-require_once 'assets/database.php';
-
-try {
-    // Create a new PDO connection
-    $pdo = new PDO("mysql:host=$dbHost;dbname=$dbName;charset=utf8", $dbUser, $dbPass);
-    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-} catch (PDOException $e) {
-    die("Database error: " . $e->getMessage());
+if (!isset($pdo) || !($pdo instanceof PDO)) {
+    $pdo = require_once __DIR__ . '/assets/database.php';
 }
 
 // Fetch cache version for cache busting


### PR DESCRIPTION
## Summary
- Remove redundant PDO creation in header and leverage shared connection from `assets/database.php`.
- Return the `$pdo` instance from `assets/database.php` so all includes use the same database handle.
- Guard header to only include the database file when a PDO instance is not already available.

## Testing
- `php -l assets/database.php`
- `php -l header.php`
- `php -l forgot_password.php`
- `php -l index.php`
- `php -l login.php`
- `php -r 'require "assets/database.php"; require "header.php"; echo ($pdo instanceof PDO) ? "has pdo" : "no pdo";'` *(fails: Failed opening required '/workspace/rhc-printshop/assets/../vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_b_6892b3a9d2f8832693a2917f54d75128