### PR TITLE
fix: reuse shared PDO in status update

### DIFF
--- a/update_status.php
+++ b/update_status.php
@@ -48,13 +48,6 @@ if (!in_array($newStatus, $allowed, true)) {
 }
 
 try {
-    $pdo = new PDO(
-        "mysql:host=$dbHost;dbname=$dbName;charset=utf8",
-        $dbUser,
-        $dbPass,
-        [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
-    );
-
     // Build UPDATE statement + params
     if ($newStatus === 'Processing') {
         $sql = "


### PR DESCRIPTION
## Summary
- reuse the database connection from `assets/database.php` in `update_status.php`
- remove leftover `$dbHost/$dbName` connection block

## Testing
- `php -l update_status.php`


------
https://chatgpt.com/codex/tasks/task_b_6892cabb19ec83268f570ac6e01e0c04