### PR TITLE
Fix ticket modal data attribute encoding

### DIFF
--- a/viewtickets.php
+++ b/viewtickets.php
@@ -178,7 +178,7 @@ document.addEventListener('DOMContentLoaded', () => {
           <button type=\"button\" class=\"btn btn-sm btn-info\"
                   data-bs-toggle=\"modal\"
                   data-bs-target=\"#ticketModal\"
-                  data-ticket='${encodeURIComponent(JSON.stringify(row))}'>View</button>
+                  data-ticket=\"${encodeURIComponent(JSON.stringify(row))}\">View</button>
           <a href=\"print_preview.php?ticket=${encodeURIComponent(row.ticket_number)}\"
              target=\"_blank\" class=\"btn btn-sm btn-secondary\">Print</a>
         </div>


### PR DESCRIPTION
## Summary
- Use double quotes around `data-ticket` so encoded JSON with apostrophes or special characters loads correctly in the ticket modal

## Testing
- `php -l viewtickets.php`
- `node <<'NODE'
const row = { job_title: "Apostrophe's & stuff", id:1, ticket_status:'New', created_at_display:'2024-01-01', date_wanted_display:'2024-01-05', first_name:"O'Neil", last_name:'Test', assigned_to:'Admin', ticket_number:'123' };
const attr = `${encodeURIComponent(JSON.stringify(row))}`;
console.log('Encoded:', attr);
const decoded = JSON.parse(decodeURIComponent(attr));
console.log('Decoded job_title:', decoded.job_title);
console.log('Decoded first_name:', decoded.first_name);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_6892dce8866c832680ef1c793c232f60