### PR TITLE
Handle DB connection failures with secure logging

### DIFF
--- a/assets/database.php
+++ b/assets/database.php
@@ -40,7 +40,8 @@ try {
         [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
     );
 } catch (PDOException $e) {
-    die('Database Connection Failed: ' . $e->getMessage());
+    error_log('DB connection failed: ' . $e->getMessage(), 3, dirname(__DIR__, 2) . '/logs/db_error.log');
+    exit('Database connection error.');
 }
 
 return $pdo;


### PR DESCRIPTION
## Summary
- Log database connection failures to a server-side log file instead of using `die`
- Return a generic error message to clients for failed DB connections

## Testing
- `php -l assets/database.php`


------
https://chatgpt.com/codex/tasks/task_b_6893b82ae3948326a52b28ddb5e5c9bb