### PR TITLE
Display formatted average completion time in analytics

### DIFF
--- a/analytics.php
+++ b/analytics.php
@@ -96,8 +96,8 @@ try {
   <div class="col-6 col-md-2">
     <div class="card text-center">
       <div class="card-body">
-        <h6>Avg Completion (hrs)</h6>
-        <h3 id="avgHours">0</h3>
+        <h6>Avg Completion</h6>
+        <h3 id="avgCompletion">0</h3>
       </div>
     </div>
   </div>
@@ -143,7 +143,7 @@ function loadStats(user='') {
       document.getElementById('topColor').textContent = d.topColor;
       document.getElementById('topType').textContent = d.topType;
       document.getElementById('topSize').textContent = d.topSize;
-      document.querySelector('#avgHours').textContent = d.avgHours;
+      document.getElementById('avgCompletion').textContent = d.avgCompletion;
 
       if (!lineChart) {
         lineChart = new Chart(document.getElementById('lineChart'), {


### PR DESCRIPTION
## Summary
- Format average job completion time into days, hours, and minutes on the backend
- Show formatted average completion on analytics page with updated element id

## Testing
- `php -l get_analytics_stats.php`
- `php -l analytics.php`


------
https://chatgpt.com/codex/tasks/task_b_68958adbf82c832689f3da00195e14a9