### PR TITLE
Remove settings user tab and fix cleanup uploads report

### DIFF
--- a/cleanup_uploads.php
+++ b/cleanup_uploads.php
@@ -58,30 +58,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
         foreach ($tickets as &$ticket) {
             $ticket['files'] = [];
             $ticket['total_size'] = 0;
-            
+
             $filePaths = explode(',', $ticket['file_path']);
             foreach ($filePaths as $path) {
                 $path = trim($path);
-                if (empty($path)) continue;
-                
-                $fullPath = $uploadDir . basename($path);
+                if (empty($path)) {
+                    continue;
+                }
+
+                // Build the full path from the stored relative path
+                $relativePath = ltrim($path, '/');
+                $fullPath = __DIR__ . '/' . $relativePath;
+
                 if (file_exists($fullPath)) {
                     $size = filesize($fullPath);
                     $ticket['total_size'] += $size;
                     $totalSize += $size;
                     $fileCount++;
-                    
+
                     $ticket['files'][] = [
-                        'path' => $path,
-                        'name' => basename($path),
+                        'path' => $relativePath,
+                        'name' => basename($relativePath),
                         'size' => $size
                     ];
                 }
             }
-            
+
             // Format size for display
             $ticket['size_formatted'] = formatFileSize($ticket['total_size']);
         }
+        unset($ticket);
         
         // Get summary statistics
         $stats = [

--- a/settings.php
+++ b/settings.php
@@ -408,11 +408,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_email'])) {
       </button>
     </li>
     <li class="nav-item" role="presentation">
-      <button class="nav-link" id="user-tab" data-bs-toggle="tab" data-bs-target="#user" type="button" role="tab" aria-controls="user" aria-selected="false">
-        <i class="bi bi-people"></i> User Management
-      </button>
-    </li>
-    <li class="nav-item" role="presentation">
       <button class="nav-link" id="data-tab" data-bs-toggle="tab" data-bs-target="#data" type="button" role="tab" aria-controls="data" aria-selected="false">
         <i class="bi bi-database"></i> Data Management
       </button>
@@ -438,9 +433,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_email'])) {
       </a></li>
       <li><a class="dropdown-item" href="#" data-target="#email" data-icon="bi-envelope">
         <i class="bi bi-envelope"></i> Email Settings
-      </a></li>
-      <li><a class="dropdown-item" href="#" data-target="#user" data-icon="bi-people">
-        <i class="bi bi-people"></i> User Management
       </a></li>
       <li><a class="dropdown-item" href="#" data-target="#data" data-icon="bi-database">
         <i class="bi bi-database"></i> Data Management
@@ -1045,10 +1037,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['update_email'])) {
     </div>
   </div>
   
-  <!-- User Management Tab -->
-  <div class="tab-pane fade" id="user" role="tabpanel" aria-labelledby="user-tab">
-    <iframe src="user_management.php" style="width:100%; height:80vh; border:0;" title="User Management"></iframe>
-  </div>
   
   <!-- Data Management Tab -->
   <div class="tab-pane fade" id="data" role="tabpanel" aria-labelledby="data-tab">


### PR DESCRIPTION
## Summary
- drop obsolete User Management tab and dropdown entries from settings since dashboard links to dedicated page
- compute cleanup upload statistics using stored relative paths so file counts and sizes report correctly

## Testing
- `php -l settings.php`
- `php -l cleanup_uploads.php`


------
https://chatgpt.com/codex/tasks/task_b_68962e46d3708326853ee0f3fe6aa86c