### PR TITLE
Add quick return to Settings for admin pages

### DIFF
--- a/activity.php
+++ b/activity.php
@@ -56,6 +56,7 @@ require 'header.php';
 ?>
 
 <div class="container-fluid">
+  <a href="settings.php" class="btn btn-secondary mb-3"><i class="bi bi-arrow-left"></i> Back to Settings</a>
   <h1>Activity History</h1>
 
   <!-- ── FILTER FORM ─────────────────────────────────────────────── -->

--- a/analytics.php
+++ b/analytics.php
@@ -31,6 +31,7 @@ try {
 }
 ?>
 
+<a href="settings.php" class="btn btn-secondary mb-3"><i class="bi bi-arrow-left"></i> Back to Settings</a>
 <h1>Analytics</h1>
 
 <div class="row mb-4">

--- a/cleanup_uploads.php
+++ b/cleanup_uploads.php
@@ -204,6 +204,7 @@ function formatFileSize($bytes) {
 }
 ?>
 
+<a href="settings.php" class="btn btn-secondary mb-3"><i class="bi bi-arrow-left"></i> Back to Settings</a>
 <h1>Semester Cleanup - Manage Uploads</h1>
 
 <?= $message ?>

--- a/delete_tickets.php
+++ b/delete_tickets.php
@@ -157,6 +157,7 @@ try {
 }
 ?>
 
+<a href="settings.php" class="btn btn-secondary mb-3"><i class="bi bi-arrow-left"></i> Back to Settings</a>
 <h1>Delete Tickets</h1>
 
 <?= $message ?>

--- a/export.php
+++ b/export.php
@@ -141,6 +141,7 @@ if ($action === 'Export CSV') {
 require_once 'header.php';
 ?>
 
+<a href="settings.php" class="btn btn-secondary mb-3"><i class="bi bi-arrow-left"></i> Back to Settings</a>
 <h1>Export Tickets</h1>
 <div class="card">
   <div class="card-header">Filter &amp; Export</div>

--- a/user_management.php
+++ b/user_management.php
@@ -83,6 +83,7 @@ function displayRole(string $r): string {
 require_once 'header.php';
 ?>
 
+<a href="settings.php" class="btn btn-secondary mb-3"><i class="bi bi-arrow-left"></i> Back to Settings</a>
 <h1>User Management</h1>
 
 <?= $message ?>


### PR DESCRIPTION
## Summary
- Add "Back to Settings" button on admin pages like user management, ticket deletion, storage cleanup, analytics, activity log, and ticket export for easier navigation

## Testing
- `php -l user_management.php`
- `php -l delete_tickets.php`
- `php -l cleanup_uploads.php`
- `php -l analytics.php`
- `php -l activity.php`
- `php -l export.php`


------
https://chatgpt.com/codex/tasks/task_b_689636f2511083268e3599cf7f3dde8f