### PR TITLE
Handle float average time in analytics

### DIFF
--- a/get_analytics_stats.php
+++ b/get_analytics_stats.php
@@ -87,7 +87,8 @@ try {
     $stmt = $pdo->prepare("SELECT AVG(TIMESTAMPDIFF(SECOND, created_at, completed_at)) FROM job_tickets WHERE ticket_status='Complete' AND completed_at IS NOT NULL$userWhere");
     $stmt->execute($bind);
     $avgSeconds = $stmt->fetchColumn();
-    if ($avgSeconds) {
+    $avgSeconds = $avgSeconds !== false ? (int)round((float)$avgSeconds) : 0;
+    if ($avgSeconds > 0) {
         $days = intdiv($avgSeconds, 86400);
         $avgSeconds %= 86400;
         $hours = intdiv($avgSeconds, 3600);


### PR DESCRIPTION
## Summary
- Cast AVG seconds to integer before computing days/hours

## Testing
- `php -l get_analytics_stats.php`


------
https://chatgpt.com/codex/tasks/task_b_6896714e0fec832690fd2c8878519639