### PR TITLE
feat: add service worker for caching

### DIFF
--- a/assets/service-worker.js
+++ b/assets/service-worker.js
@@ -1,0 +1,65 @@
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `rhc-printshop-${CACHE_VERSION}`;
+const PRECACHE_URLS = [
+  '/',
+  '/index.php',
+  '/assets/css/style.css',
+  '/assets/apple-touch-icon.png',
+  '/assets/favicon-32x32.png',
+  '/assets/favicon-16x16.png',
+  '/site.webmanifest'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const request = event.request;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          return response;
+        })
+        .catch(() => caches.match(request))
+    );
+  } else {
+    event.respondWith(
+      caches.match(request).then(cached => {
+        return (
+          cached ||
+          fetch(request).then(response => {
+            if (response.status === 200) {
+              const copy = response.clone();
+              caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+            }
+            return response;
+          })
+        );
+      })
+    );
+  }
+});
+

--- a/header.php
+++ b/header.php
@@ -193,6 +193,18 @@ setInterval(updateTicketBadges, 30000);
   gtag('config', 'G-VC0R4BEX9B');
 </script>
 
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('assets/service-worker.js')
+        .catch(function(err) {
+          console.error('Service worker registration failed:', err);
+        });
+    }
+  });
+</script>
+
 </head>
 
 <body class="bg-light">


### PR DESCRIPTION
## Summary
- add versioned service worker that precaches core assets and applies caching strategies
- register the service worker after DOM ready so clients receive updates when the worker changes

## Testing
- `php -l header.php`
- `node --check assets/service-worker.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_b_68968304a5ac83268dcbc20aca7b3a8f