### PR TITLE
feat: enable long-term caching for assets

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -48,6 +48,12 @@
         Order Allow,Deny
         Allow from all
     </FilesMatch>
+    <IfModule mod_headers.c>
+        # Long-term caching for static assets; cache bust with cache_version query strings
+        <FilesMatch "\.(?:css|js|png|jpg|jpeg|gif|svg|webp|woff|woff2|ttf|otf|ico)$">
+            Header set Cache-Control "public, max-age=31536000"
+        </FilesMatch>
+    </IfModule>
 </Directory>
 
 <Directory "helpers/">


### PR DESCRIPTION
## Summary
- add long-term caching headers to assets directory and rely on existing cache_version query strings for busting

## Testing
- `apache2ctl configtest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6896d84c0ce48326a7ceea5f26dfe1b6