### PR TITLE
perf: add preconnect hints for key third-party origins

### DIFF
--- a/header.php
+++ b/header.php
@@ -94,11 +94,13 @@ if (empty($_SESSION['form_token'])) {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="noindex, nofollow">
+  <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+  <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
   <link rel="apple-touch-icon" sizes="180x180" href="./assets/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="./assets/favicon-16x16.png">
      <link rel="manifest" href="./site.webmanifest">
-  <title><?php 
+  <title><?php
   $pageTitle = 'Printshop Dashboard';
   if (basename($_SERVER['PHP_SELF']) === 'newticket.php') $pageTitle = 'Submit Print Request';
   elseif (basename($_SERVER['PHP_SELF']) === 'viewtickets.php') $pageTitle = 'View Tickets';


### PR DESCRIPTION
## Summary
- Add preconnect hints for CDN and Google Tag Manager to speed up resource fetches

## Testing
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_b_6896d9302fbc8326bc41e7082207580e