### PR TITLE
Avoid passing null to htmlspecialchars in update_status

### DIFF
--- a/update_status.php
+++ b/update_status.php
@@ -157,7 +157,7 @@ $log->execute([
                 );
             } else {
                 $assignedToName = htmlspecialchars(
-                    $ticket['assigned_to'],
+                    $ticket['assigned_to'] ?? '',
                     ENT_QUOTES, 'UTF-8'
                 );
             }


### PR DESCRIPTION
## Summary
- prevent deprecated warning by defaulting to empty string when `assigned_to` is null in `update_status.php`

## Testing
- `php -l update_status.php`


------
https://chatgpt.com/codex/tasks/task_b_689a4346402c83268fb402d8176dc372