### PR TITLE
Add developer impersonation capability

### DIFF
--- a/header.php
+++ b/header.php
@@ -285,12 +285,19 @@ setInterval(updateTicketBadges, 30000);
       <?php endif; ?>
     <?php endif; ?>
 
-    <!-- Always show Logout when logged in -->
-    <li class="nav-item">
-      <a href="logout.php" class="nav-link">
-        <i class="bi bi-box-arrow-right" aria-hidden="true"></i> Logout
-      </a>
-    </li>
+      <?php if (!empty($_SESSION['original_user'])): ?>
+        <li class="nav-item">
+          <a href="stop_impersonate.php" class="nav-link text-warning">
+            <i class="bi bi-person-x" aria-hidden="true"></i> Stop Impersonating
+          </a>
+        </li>
+      <?php endif; ?>
+      <!-- Always show Logout when logged in -->
+      <li class="nav-item">
+        <a href="logout.php" class="nav-link">
+          <i class="bi bi-box-arrow-right" aria-hidden="true"></i> Logout
+        </a>
+      </li>
   <?php endif; ?>
 </ul>
 
@@ -370,6 +377,13 @@ setInterval(updateTicketBadges, 30000);
       <?php endif; ?>
     <?php endif; ?>
 
+    <?php if (!empty($_SESSION['original_user'])): ?>
+      <li class="nav-item">
+        <a href="stop_impersonate.php" class="nav-link text-warning">
+          <i class="bi bi-person-x" aria-hidden="true"></i> Stop Impersonating
+        </a>
+      </li>
+    <?php endif; ?>
     <!-- Always show Logout when logged in -->
     <li class="nav-item">
       <a href="logout.php" class="nav-link">

--- a/impersonate_user.php
+++ b/impersonate_user.php
@@ -1,0 +1,57 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Load database connection
+$pdo = require __DIR__ . '/assets/database.php';
+$protectedUsers = require __DIR__ . '/config/protected_users.php';
+
+// Verify the current user is allowed to impersonate
+if (
+    empty($_SESSION['logged_in']) ||
+    empty($_SESSION['username']) ||
+    !in_array($_SESSION['username'], $protectedUsers, true)
+) {
+    header('Location: login.php');
+    exit;
+}
+
+// Accept target username via GET or POST
+$target = $_GET['target'] ?? $_POST['target'] ?? '';
+$target = trim($target);
+
+if ($target === '' || in_array($target, $protectedUsers, true)) {
+    header('Location: user_management.php');
+    exit;
+}
+
+try {
+    $stmt = $pdo->prepare('SELECT username, role FROM users WHERE username = :u LIMIT 1');
+    $stmt->execute([':u' => $target]);
+    $user = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$user) {
+        header('Location: user_management.php');
+        exit;
+    }
+
+    // Save the original developer credentials if not already stored
+    if (empty($_SESSION['original_user'])) {
+        $_SESSION['original_user'] = [
+            'username' => $_SESSION['username'],
+            'role' => $_SESSION['role'] ?? ''
+        ];
+    }
+
+    // Copy target credentials into session
+    $_SESSION['username'] = $user['username'];
+    $_SESSION['role'] = $user['role'];
+    $_SESSION['logged_in'] = true;
+
+    header('Location: index.php');
+    exit;
+} catch (PDOException $e) {
+    header('Location: user_management.php');
+    exit;
+}

--- a/stop_impersonate.php
+++ b/stop_impersonate.php
@@ -1,0 +1,32 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$pdo = require __DIR__ . '/assets/database.php';
+
+// Ensure an impersonation is active
+if (empty($_SESSION['original_user'])) {
+    header('Location: login.php');
+    exit;
+}
+
+// Log out of the impersonated account
+$impersonated = $_SESSION['username'] ?? null;
+if ($impersonated) {
+    try {
+        $stmt = $pdo->prepare("INSERT INTO activity_log (username, event) VALUES (:u, 'logout')");
+        $stmt->execute([':u' => $impersonated]);
+    } catch (PDOException $e) {
+        // Ignore logging errors
+    }
+}
+
+// Restore original user credentials
+$_SESSION['username'] = $_SESSION['original_user']['username'];
+$_SESSION['role'] = $_SESSION['original_user']['role'];
+unset($_SESSION['original_user']);
+$_SESSION['logged_in'] = true;
+
+header('Location: index.php');
+exit;

--- a/user_management.php
+++ b/user_management.php
@@ -157,6 +157,12 @@ require_once 'header.php';
                      onclick="return confirm('Delete <?= htmlspecialchars($u['username']) ?>?');">
                     <i class="bi bi-trash"></i>
                   </a>
+                  <?php if (in_array($_SESSION['username'], $protectedUsers, true)): ?>
+                  <a href="impersonate_user.php?target=<?= urlencode($u['username']) ?>"
+                     class="btn btn-sm btn-outline-secondary ms-1">
+                    <i class="bi bi-person-badge"></i>
+                  </a>
+                  <?php endif; ?>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Allow protected developers to switch into another user's account via `impersonate_user.php`
- Provide `stop_impersonate.php` to restore original identity and log the impersonated logout
- Expose impersonation controls in user management and navigation when a developer is logged in

## Testing
- `php -l impersonate_user.php`
- `php -l stop_impersonate.php`
- `php -l user_management.php`
- `php -l header.php`


------
https://chatgpt.com/codex/tasks/task_b_689a7a1032e48326abdd9b2d365ac3a2