### PR TITLE
Block deletion of canceled tickets

### DIFF
--- a/delete_tickets.php
+++ b/delete_tickets.php
@@ -23,9 +23,9 @@ $message = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_ticket'])) {
     $ticketId = (int)$_POST['delete_ticket'];
 
-    // 1) Fetch ticket_number + file paths
+    // 1) Fetch ticket_number + file paths + status
     $fetch = $pdo->prepare("
-      SELECT ticket_number, file_path
+      SELECT ticket_number, file_path, status
         FROM job_tickets
        WHERE id = :id
        LIMIT 1
@@ -33,40 +33,46 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['delete_ticket'])) {
     $fetch->execute([':id' => $ticketId]);
     $row = $fetch->fetch(PDO::FETCH_ASSOC);
 
-    // 2) Delete the record
-    $del = $pdo->prepare("DELETE FROM job_tickets WHERE id = :id");
-    $del->execute([':id' => $ticketId]);
+    if (!$row) {
+        $message = '<div class="alert alert-danger">Ticket not found.</div>';
+    } elseif ($row['status'] === 'Canceled') {
+        $message = '<div class="alert alert-danger">Cannot delete a canceled ticket.</div>';
+    } else {
+        // 2) Delete the record
+        $del = $pdo->prepare("DELETE FROM job_tickets WHERE id = :id");
+        $del->execute([':id' => $ticketId]);
 
-    if ($del->rowCount()) {
-        // 3) Remove uploaded files
-        if (!empty($row['file_path'])) {
-            $uploadDir = __DIR__ . '/uploads/';
-            foreach (explode(',', $row['file_path']) as $p) {
-                $full = $uploadDir . basename(trim($p));
-                if (file_exists($full)) {
-                    @unlink($full);
+        if ($del->rowCount()) {
+            // 3) Remove uploaded files
+            if (!empty($row['file_path'])) {
+                $uploadDir = __DIR__ . '/uploads/';
+                foreach (explode(',', $row['file_path']) as $p) {
+                    $full = $uploadDir . basename(trim($p));
+                    if (file_exists($full)) {
+                        @unlink($full);
+                    }
                 }
             }
+
+            // 4) Log the deletion in activity_log
+            $log = $pdo->prepare("
+              INSERT INTO activity_log (username, event, details)
+              VALUES (:u, 'delete_ticket', :d)
+            ");
+            $details = "Ticket #{$row['ticket_number']}";
+            $log->execute([
+              ':u' => $_SESSION['username'],
+              ':d' => $details,
+            ]);
+
+            $message = '<div class="alert alert-success">'
+                     . 'Ticket deleted successfully.'
+                     . '</div>';
+        } else {
+            $message = '<div class="alert alert-danger">'
+                     . 'Could not delete ticket (not found?).'
+                     . '</div>';
         }
-
-        // 4) Log the deletion in activity_log
-        $log = $pdo->prepare("
-          INSERT INTO activity_log (username, event, details)
-          VALUES (:u, 'delete_ticket', :d)
-        ");
-        $details = "Ticket #{$row['ticket_number']}";
-        $log->execute([
-          ':u' => $_SESSION['username'],
-          ':d' => $details,
-        ]);
-
-        $message = '<div class="alert alert-success">'
-                 . 'Ticket deleted successfully.'
-                 . '</div>';
-    } else {
-        $message = '<div class="alert alert-danger">'
-                 . 'Could not delete ticket (not found?).'
-                 . '</div>';
     }
 }
 
@@ -75,11 +81,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_delete'], $_POST
     $ticketIds = array_map('intval', $_POST['ticket_ids']);
     $deletedCount = 0;
     $ticketNumbers = [];
+    $skippedIds = [];
 
     foreach ($ticketIds as $ticketId) {
-        // 1) Fetch ticket_number + file paths
+        // 1) Fetch ticket_number + file paths + status
         $fetch = $pdo->prepare("
-          SELECT ticket_number, file_path
+          SELECT ticket_number, file_path, status
             FROM job_tickets
            WHERE id = :id
            LIMIT 1
@@ -88,6 +95,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_delete'], $_POST
         $row = $fetch->fetch(PDO::FETCH_ASSOC);
 
         if (!$row) continue;
+
+        if ($row['status'] === 'Canceled') {
+            $skippedIds[] = $ticketId;
+            continue;
+        }
 
         // 2) Delete the record
         $del = $pdo->prepare("DELETE FROM job_tickets WHERE id = :id");
@@ -121,7 +133,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_delete'], $_POST
           ':u' => $_SESSION['username'],
           ':d' => $details,
         ]);
-
         $message = '<div class="alert alert-success">'
                  . 'Successfully deleted ' . $deletedCount . ' tickets.'
                  . '</div>';
@@ -129,6 +140,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['bulk_delete'], $_POST
         $message = '<div class="alert alert-danger">'
                  . 'No tickets were deleted.'
                  . '</div>';
+    }
+
+    if (!empty($skippedIds)) {
+        $message .= '<div class="alert alert-warning">Skipped ID(s): ' . implode(', ', $skippedIds) . ' (Canceled).</div>';
     }
 }
 

--- a/settings.php
+++ b/settings.php
@@ -56,29 +56,40 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt->execute([':tn' => $delTicketNumber]);
             $delTicket = $stmt->fetch(PDO::FETCH_ASSOC);
         } else {
-            // grab file paths
-            $stmt = $pdo->prepare("SELECT file_path FROM job_tickets WHERE ticket_number = :tn LIMIT 1");
+            // grab file paths and status
+            $stmt = $pdo->prepare("SELECT file_path, status FROM job_tickets WHERE ticket_number = :tn LIMIT 1");
             $stmt->execute([':tn' => $delTicketNumber]);
             $row = $stmt->fetch(PDO::FETCH_ASSOC);
-            // delete row
-            $delStmt = $pdo->prepare("DELETE FROM job_tickets WHERE ticket_number = :tn");
-            $delStmt->execute([':tn' => $delTicketNumber]);
-            // remove uploads
-            if (!empty($row['file_path'])) {
-                $uploadDir = __DIR__ . '/uploads/';
-                foreach (explode(',', $row['file_path']) as $p) {
-                    $p = trim($p);
-                    $full = $uploadDir . basename($p);
-                    if (file_exists($full)) {
-                        unlink($full);
+
+            if (!$row) {
+                $deleteMessage = '<div class="alert alert-danger">Ticket not found.</div>';
+            } elseif ($row['status'] === 'Canceled') {
+                $deleteMessage = '<div class="alert alert-danger">Cannot delete a ticket with status Canceled.</div>';
+                // re-fetch full ticket to re-display details
+                $stmt       = $pdo->prepare("SELECT * FROM job_tickets WHERE ticket_number = :tn LIMIT 1");
+                $stmt->execute([':tn' => $delTicketNumber]);
+                $delTicket = $stmt->fetch(PDO::FETCH_ASSOC);
+            } else {
+                // delete row
+                $delStmt = $pdo->prepare("DELETE FROM job_tickets WHERE ticket_number = :tn");
+                $delStmt->execute([':tn' => $delTicketNumber]);
+                // remove uploads
+                if (!empty($row['file_path'])) {
+                    $uploadDir = __DIR__ . '/uploads/';
+                    foreach (explode(',', $row['file_path']) as $p) {
+                        $p = trim($p);
+                        $full = $uploadDir . basename($p);
+                        if (file_exists($full)) {
+                            unlink($full);
+                        }
                     }
                 }
+                $deleteMessage = '<div class="alert alert-success">'
+                               . "Ticket #".htmlspecialchars($delTicketNumber)." deleted successfully."
+                               . '</div>';
+                $delTicket = null;
+                $delTicketNumber = '';
             }
-            $deleteMessage = '<div class="alert alert-success">'
-                           . "Ticket #".htmlspecialchars($delTicketNumber)." deleted successfully."
-                           . '</div>';
-            $delTicket = null;
-            $delTicketNumber = '';
         }
     }
 }


### PR DESCRIPTION
## Summary
- prevent single ticket deletion when status is Canceled
- skip Canceled tickets in bulk deletion and report skipped IDs
- stop settings deletion workflow if ticket is Canceled

## Testing
- `php -l delete_tickets.php`
- `php -l settings.php`


------
https://chatgpt.com/codex/tasks/task_b_689b98c08f5883269b4e3a98718c5cbd