### PR TITLE
Add 24lb paper option with pricing support

### DIFF
--- a/newticket.php
+++ b/newticket.php
@@ -206,6 +206,7 @@ try {
         <label for="page_type" class="form-label">Page Type / Weight</label>
         <select name="page_type" id="page_type" class="form-select">
           <option value="Standard 20#">Standard 20#</option>
+          <option value="24lb">24lb</option>
           <option value="Card Stock">Card Stock</option>
           <option value="NCR 2-Part">NCR 2-Part</option>
           <option value="NCR 3-Part">NCR 3-Part</option>
@@ -972,6 +973,8 @@ function calculateEstimate() {
     // Black & White pricing
     if (pageType === 'Card Stock') {
       baseCost = 0.25; // Cardstock 65lb - all sizes same price for B&W
+    } else if (pageType === '24lb') {
+      baseCost = paperSize.includes('Ledger') ? 0.50 : 0.25; // 24lb paper pricing
     } else if (paperSize.includes('Ledger')) {
       baseCost = 0.10; // Ledger (White)
     } else {
@@ -986,6 +989,13 @@ function calculateEstimate() {
         baseCost = 0.50; // Cardstock Ledger
       } else {
         baseCost = 0.25; // Cardstock Letter/Legal
+      }
+    } else if (pageType === '24lb') {
+      // 24lb paper pricing for color
+      if (paperSize.includes('Ledger: 11"x17"')) {
+        baseCost = 0.50; // 24lb Color Ledger
+      } else {
+        baseCost = 0.25; // 24lb Color Letter/Legal
       }
     } else {
       // Standard paper for color


### PR DESCRIPTION
## Summary
- expose new 24lb paper type in ticket form
- calculate costs for 24lb paper in Black & White and Color estimates

## Testing
- `php -l newticket.php`


------
https://chatgpt.com/codex/tasks/task_b_689f4687fef48326b5469f1e163d5398